### PR TITLE
Handle unicode strings properly

### DIFF
--- a/shipstation/api.py
+++ b/shipstation/api.py
@@ -20,6 +20,7 @@ class ShipStationBase(object):
             if value is None:
                 d[key] = None
             else:
+                if type(value) == unicode: value = value.encode('ascii', errors='replace')                
                 d[key] = str(value)
 
         return d


### PR DESCRIPTION
If there is a string in the dictionary which is unicode with non-ascii characters, the str(value) will throw an exception.  So, we should check that the type is unicode and convert it first - and ignore/replace/xmlcharrefreplace errors.