### PR TITLE
feat: switch to pytest, add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 dist
 shipstation.egg-info
 .tox
+.coverage
 .idea
 build/lib/*
-
+Pipfile
+Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/natecox/pyshipstation.svg?branch=develop)](https://travis-ci.org/natecox/pyshipstation)
+![](coverage.svg)
 
 # Shipstation API Python Bindings
 This package provides the basic API bindings for interacting with
@@ -154,10 +155,10 @@ This corresponds to the Address model in ShipStation
         postal_code=['zip code'],
         country='[two letter country code]'
     )
-    
+
 ## Get existing ShipStation Orders
 You can get existing orders from ShipStation with parameter filtering, and do what you wish with the Response object returned.
- 
+
     response = ss.fetch_orders()
 
 The allowed filter list is:

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">66%</text>
+        <text x="80" y="14">66%</text>
+    </g>
+</svg>

--- a/tests/test_customs_item.py
+++ b/tests/test_customs_item.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.tools import raises
+import pytest
 from shipstation.api import *
 from decimal import Decimal
 
@@ -40,23 +40,23 @@ class ShipStationTests(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_customs_item_must_have_description(self):
         ShipStationCustomsItem(
             description="", harmonized_tariff_code="test", country_of_origin="us"
         )
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_customs_item_must_have_tariff_code(self):
         ShipStationCustomsItem(
             description="test", harmonized_tariff_code="", country_of_origin="us"
         )
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_customs_item_must_have_country_code(self):
         ShipStationCustomsItem(description="test", harmonized_tariff_code="test")
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_customs_item_must_have_two_character_country_code(self):
         ShipStationCustomsItem(
             description="test",

--- a/tests/test_international_options.py
+++ b/tests/test_international_options.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.tools import raises
+import pytest
 from shipstation.api import *
 from decimal import Decimal
 
@@ -36,10 +36,10 @@ class ShipStationTests(unittest.TestCase):
 
         self.assertDictEqual(expected, actual)
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_international_options_contents_must_be_valid(self):
         self.ss_intl.set_contents("something_else")
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_international_options_non_delivery_must_be_valid(self):
         self.ss_intl.set_non_delivery("something_else")

--- a/tests/test_order_fetch.py
+++ b/tests/test_order_fetch.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.tools import raises
+import pytest
 from shipstation.api import *
 
 
@@ -10,10 +10,10 @@ class ShipStationApiTests(unittest.TestCase):
     def tearDown(self):
         self.ss = None
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_fetch_orders_must_be_dict(self):
         self.ss.fetch_orders(parameters="non dict")
 
-    @raises(AttributeError)
+    @pytest.mark.xfail(raises=AttributeError)
     def test_fetch_orders_must_use_correct_parameter(self):
         self.ss.fetch_orders(parameters={"bad": "not good"})

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py2714,py355,py364,py373
+envlist = py2714,py355,py365,py375,py381
 
 [testenv]
-commands = nosetests {posargs}
-deps = nose
+deps =
+  pytest
+  pytest-cov
+commands = pytest --cov={envsitepackagesdir}/shipstation tests/


### PR DESCRIPTION
This switches test utilities away from nose (which is formally unmaintained) to pytest and includes coverage calculation and a badge in the readme.
Updated the versions of python to 3.6 and 3.7 final and added 3.8.1