### PR TITLE
api.py: Change very short Requests timeout default to None

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/shipstation/api.py
+++ b/shipstation/api.py
@@ -12,7 +12,7 @@ class ShipStation(ShipStationBase):
     Handles the details of connecting to and querying a ShipStation account.
     """
 
-    def __init__(self, key=None, secret=None, debug=False):
+    def __init__(self, key=None, secret=None, debug=False, timeout=None):
         """
         Connecting to ShipStation required an account and a
         :return:
@@ -28,7 +28,7 @@ class ShipStation(ShipStationBase):
         self.key = key
         self.secret = secret
         self.orders = []
-        self.timeout = 1.0
+        self.timeout = timeout
         self.debug = debug
 
     def add_order(self, order):


### PR DESCRIPTION
The default timeout is just one second. I couldn't read the fifth or later page of results without the request failing. It's now a constructor parameter with a default value of None. We no longer hard-code an arbitrary, non-default value.